### PR TITLE
Escape file paths

### DIFF
--- a/valet.php
+++ b/valet.php
@@ -148,6 +148,10 @@ $app->command('which', function () {
 $app->command('logs', function () {
     $files = Site::logs(Configuration::read()['paths']);
 
+    $files = collect($files)->transform(function ($file) {
+        return escapeshellarg($file);
+    })->all();
+
     if (count($files) > 0) {
         passthru('tail -f '.implode(' ', $files));
     } else {


### PR DESCRIPTION
Use escapeshellarg to make file paths safe to use in shell command
